### PR TITLE
Fix assembly locking issues on V8Bridge.dll

### DIFF
--- a/SassAndCoffee/JavascriptInterop.cs
+++ b/SassAndCoffee/JavascriptInterop.cs
@@ -158,7 +158,7 @@ namespace SassAndCoffee
                 string assemblyResource = (Environment.Is64BitProcess ?
                     "SassAndCoffee.lib.amd64.V8Bridge.dll" : "SassAndCoffee.lib.x86.V8Bridge.dll");
 
-                var v8Name = Path.Combine(Path.GetTempPath(), "V8Bridge.dll");
+                var v8Name = Path.GetTempFileName() + ".dll";
                 using (var of = File.OpenWrite(v8Name)) {
                     Assembly.GetExecutingAssembly().GetManifestResourceStream(assemblyResource).CopyTo(of);
                 }


### PR DESCRIPTION
If multiple sites are running on the same machine, they all try to grab the same assembly which has caused locking issues in our case. This patch fixes that by ensuring each instance has its own assembly.
