### PR TITLE
Issue 7

### DIFF
--- a/SassAndCoffee.AspNet/CompilableFileHandler.cs
+++ b/SassAndCoffee.AspNet/CompilableFileHandler.cs
@@ -29,6 +29,7 @@
             if (fi.Exists) {
                 BuildHeaders(context.Response, _contentCompiler.GetOutputMimeType(requestedFileName), fi.LastWriteTimeUtc);
                 context.Response.WriteFile(requestedFileName);
+                context.Response.Flush();
                 return;
             }
 


### PR DESCRIPTION
Hey!

This here seems to fix the problem raised in Issue 7.
The core of the problem seems to be that when ie a JS file is requested and sent to the client it gets header: 

Content-Encoding: gzip

but without flushing the file sometimes get sent with encoding header, but with actual content not being encoded, resulting in the error described.

I'm not familiar enough with compression to really know whats going on, but after adding this little thingy here I can not reproduce the problem on my environment again.
