### PR TITLE
Fix for "undefined is not a function" when combining minified JavaScript

### DIFF
--- a/SassAndCoffee.Core/Compilers/FileConcatenationCompiler.cs
+++ b/SassAndCoffee.Core/Compilers/FileConcatenationCompiler.cs
@@ -47,8 +47,11 @@ namespace SassAndCoffee.Core.Compilers
                 .ToArray();
 
             return allText.Aggregate(new StringBuilder(), (acc, x) => {
-                acc.Append(x);
-                acc.Append("\n");
+                if (!String.IsNullOrEmpty(x))
+                {
+                    acc.Append(x);
+                    acc.Append(";\n");                    
+                }
                 return acc;
             }).ToString();
         }


### PR DESCRIPTION
When Uglify minifies JavaScript any trailing semicolons are truncated. If the JavaScript is a closure (such as jQuery) this causes an error when multiple files comprising of closures are combined. Ensuring that each compiled file content has a semicolon appended fixes the error.

In addition, a check is performed to verify that there is compiled content for each iteration to append to the output.
