### PR TITLE
Allow compilation of sass via string parameters instead of solely file-based sass compilation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.log
 *.lib
 *.ncb
+*.ncrunchsolution
 *.obj
 *.opensdf
 *.orig
@@ -31,6 +32,7 @@
 [Dd]ebug/
 [Rr]elease/
 _ReSharper
+_ReSharper.*
 TestResults/
 packages/
 

--- a/SassAndCoffee.Ruby/Sass/ISassCompiler.cs
+++ b/SassAndCoffee.Ruby/Sass/ISassCompiler.cs
@@ -4,5 +4,7 @@
 
     public interface ISassCompiler : IDisposable {
         string Compile(string path, bool compressed, IList<string> dependentFileList);
+        string CompileScss(string input, bool compressed);
+        string CompileSass(string input, bool compressed);
     }
 }

--- a/SassAndCoffee.Ruby/Sass/SassCompilerProxy.cs
+++ b/SassAndCoffee.Ruby/Sass/SassCompilerProxy.cs
@@ -12,5 +12,13 @@
         public string Compile(string path, bool compressed, IList<string> dependentFileList) {
             return WrappedItem.Compile(path, compressed, dependentFileList);
         }
+
+        public string CompileScss(string input, bool compressed) {
+            return WrappedItem.CompileScss(input, compressed);
+        }
+
+        public string CompileSass(string input, bool compressed) {
+            return WrappedItem.CompileSass(input, compressed);
+        }
     }
 }


### PR DESCRIPTION
This change allows callers to compile a sass or scss string - basically: string in, string out.

One of the reasons this would be useful, at least for us, is that we use render dynamic CSS (i.e. with  `ContentResult { ContentType = "text/css", Content = someGeneratedContent }`). Our design team began using sass for their designs so we were looking into pulling in sass anyway, but by generating sass instead of CSS, it would be easy to merge our changes with their changes.
