### PR TITLE
Fixed MethodNotFound Exception

### DIFF
--- a/SassAndCoffee.Ruby/Sass/lib/sass_in_one.rb
+++ b/SassAndCoffee.Ruby/Sass/lib/sass_in_one.rb
@@ -1,3 +1,9 @@
+# See:http://marcel.bowlitz.com/ironruby/ironruby-and-the-dreaded-method-not-found-error/
+class System::Object
+  def initialize
+  end
+end
+
 # This is necessary to set so that the Haml code that tries to load Sass
 # knows that Sass is indeed loading,
 # even if there's some crazy autoload stuff going on.


### PR DESCRIPTION
When attempting to use Cassette (getcassette.net) which uses SassAndCoffee as a dependency, I got the following exception.

Method not found: 'Microsoft.Scripting.Actions.Calls.OverloadInfo[] Microsoft.Scripting.Actions.Calls.ReflectionOverloadInfo.CreateArray(System.Reflection.MemberInfo[])'.

See http://marcel.bowlitz.com/ironruby/ironruby-and-the-dreaded-method-not-found-error/ for more information.
